### PR TITLE
Fix fatal crash unloading maps with custom localize assets (dedicated)

### DIFF
--- a/src/db_load.cpp
+++ b/src/db_load.cpp
@@ -2986,7 +2986,9 @@ void __cdecl DB_UnloadXZoneInternal(unsigned int zoneIndex, bool createDefault)
           }
           *pAssetEntryIndex = assetEntry->nextHash;
           DB_FreeXAssetEntry(assetEntry);
-          if ( *g_defaultAssetName[asset.type] )
+          // No default LOCALIZE_ENTRY on a dedicated server ("CGAME_UNKNOWN" is client-only), so maps with
+          // custom localized strings crash here on unload. Safe to free without a stub (name-resolved).
+          if ( *g_defaultAssetName[asset.type] && asset.type != ASSET_TYPE_LOCALIZE_ENTRY )
           {
             Sys_LeaveCriticalSection(CRITSECT_DBHASH);
             Sys_Error("Could not load default asset for asset type '%s'", (&g_assetNames)[asset.type]);


### PR DESCRIPTION
On a dedicated server, unloading a fastfile that contains custom localized strings (ASSET_TYPE_LOCALIZE_ENTRY) fatally aborts:

    Sys_Error: Could not load default asset for asset type ''

DB_UnloadXZoneInternal creates default stubs for the zone's assets, but the default for LOCALIZE_ENTRY is "CGAME_UNKNOWN", which ships only in the client localizedstrings zones a dedicated server never loads. DB_FindXAssetDefault- HeaderInternal returns NULL and the server dies. A client/listen server (and stock iw3) loads CGAME_UNKNOWN and unloads the same map cleanly; only maps that bake their own localize entries reach this path.

Skip the missing-default fatal for LOCALIZE_ENTRY. Freeing it without a stub is safe: localized strings are resolved by name at display time and never held by pointer, the same reasoning that already leaves RAWFILE / MAP_ENTS without a default.

(db_xassetdebug 1 names the culprit: the last "removing asset" line before the abort is the localize entry with no "using default" follow-up.)