### PR TITLE
Fix Scr_GetConstString narrowing string indices to a signed short

### DIFF
--- a/src/scr_vm.h
+++ b/src/scr_vm.h
@@ -708,7 +708,9 @@ int __cdecl Scr_GetInt( unsigned int );
 float __cdecl Scr_GetFloat( unsigned int );
 char* __cdecl Scr_GetString( unsigned int );
 gentity_t* __cdecl Scr_GetEntity( unsigned int );
-short __cdecl Scr_GetConstString( unsigned int );
+/* Returns a full 32-bit script string index. Must not be narrowed here: declaring
+   this `short` makes the caller sign-extend any index >= 0x8000 into 0xFFFFxxxx. */
+unsigned int __cdecl Scr_GetConstString( unsigned int );
 unsigned int __cdecl Scr_GetType( unsigned int );
 unsigned int __cdecl Scr_GetPointerType( unsigned int );
 void __cdecl Scr_GetVector( unsigned int, float* );

--- a/src/scr_vm_functions.c
+++ b/src/scr_vm_functions.c
@@ -3411,7 +3411,7 @@ void PlayerCmd_SetStance(scr_entref_t playerEntNum)
         Scr_ObjectError("entity is not a client");
 
     // Param check.
-    short stanceIdx = Scr_GetConstString(0);
+    unsigned int stanceIdx = Scr_GetConstString(0);
     if (stanceIdx != (unsigned short)scr_const.stand && stanceIdx != (unsigned short)scr_const.crouch && stanceIdx != (unsigned short)scr_const.prone)
         Scr_ParamError(0, "stance must be one of {stand, crouch, prone}");
 

--- a/src/sv_bots.cpp
+++ b/src/sv_bots.cpp
@@ -300,7 +300,7 @@ static void scr_botlookatplayer(scr_entref_t ent_num)
     gentity_t *target;
     int argc;
     vec3_t look_origin;
-    short tag_name;
+    unsigned int tag_name;
     mvabuf;
 
     bot = VM_GetGEntityForEntRef(ent_num);


### PR DESCRIPTION
Scr_GetConstString is prototyped as

    short __cdecl Scr_GetConstString(unsigned int);

but the engine function returns a full 32-bit script string index in EAX. There is no local definition, so this declaration is the ABI contract: declared signed 16-bit, the compiler takes AX and sign-extends it at every call site. Index 0x892E reaches the caller as 0xFFFF892E.

Sign extension only bites once bit 15 is set, i.e. index >= 32768, which is why this has gone unnoticed. A gametype has to intern enough strings to cross that threshold before anything misbehaves -- linking a few dozen extra .gsc files is enough, the same content in fewer files is not. That makes it present as a content problem rather than an engine one, and it is stable either side of the line, so it reproduces perfectly and bisects to nothing.

The callee is fine -- Scr_CastString returns immediately for VAR_STRING and Scr_GetConstString_50 is a full 32-bit load. The widening is emitted in the caller, straight from the prototype.

Declare the return type unsigned int to match what the function returns, and widen the two locals that stored it as a short. Both are reachable from script:

PlayerCmd_SetStance: the corrupted index never compares equal to scr_const.stand/crouch/prone, so a valid setStance() call is rejected with "stance must be one of {stand, crouch, prone}". Contained, but wrong.

scr_botlookatplayer: the two-argument botLookAtPlayer(<player>, <tag>) form stores the index in a short, so the tag lookup cannot match and control reaches the error path, which formats the message with SL_ConvertToString(tag_name). That resolves through MT_GetRefByIndex, whose bounds check tests only index > MEMORY_NODE_COUNT -- a negative index passes it and yields a pointer below gScrMemTreeGlob.nodes, which is then dereferenced and walked as a string. The one-argument form defaults to scr_const.pelvis, interned at VM init with a low index, and is unaffected.

Scr_ExecEntThread and Scr_ExecThread are declared short as well. They were checked and cleared, and are left as they are: their return value is a 16-bit thread id by design, not a narrowed 32-bit one. Every call site assigns it to a local and passes it straight to Scr_FreeThread(short), and nothing else consumes it. Two of those locals are int, so the id does sign-extend on the way in, but Scr_FreeThread truncates it back to the same 16 bits and the round trip is lossless.